### PR TITLE
feat: add JSON/text output format to SandboxRunner CLI

### DIFF
--- a/SandboxRunner/CMakeLists.txt
+++ b/SandboxRunner/CMakeLists.txt
@@ -3,7 +3,8 @@ add_executable (SandboxRunner "SandboxRunner.cpp" "SandboxRunner.h" "../ThirdPar
 target_include_directories(SandboxRunner PRIVATE ../ThirdParty)
 
 find_package(stduuid CONFIG REQUIRED)
-target_link_libraries(SandboxRunner PRIVATE sandbox stduuid)
+find_package(nlohmann_json CONFIG REQUIRED)
+target_link_libraries(SandboxRunner PRIVATE sandbox stduuid nlohmann_json::nlohmann_json)
 sandboxrunner_configure_target(SandboxRunner)
 
 add_dependencies(BUILD_ALL sandbox)

--- a/SandboxRunner/SandboxRunner.cpp
+++ b/SandboxRunner/SandboxRunner.cpp
@@ -2,24 +2,77 @@
 #include "../SandboxRunnerCore/Sandbox.h"
 #include "cmdline.h"
 #include "stduuid/uuid.h"
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <nlohmann/json.hpp>
 
-SandboxConfiguration GetSandboxConfiguration(int argc, char **argv);
-
-int main(int argc, char *argv[])
+struct CliOptions
 {
-    SandboxConfiguration configuration = GetSandboxConfiguration(argc, argv);
-    SandboxResult result{};
-    
-    if (int status = StartSandbox(&configuration, &result); status != SANDBOX_STATUS_SUCCESS)
-    {
-        fprintf(stderr, "Failed to start sandbox\n");
-        return status;
-    }
-    return 0;
-}
+    SandboxConfiguration Configuration;
+    std::string Format;
+};
+
+CliOptions GetCliOptions(int argc, char **argv);
 
 namespace
 {
+
+const char *GetStatusName(int status)
+{
+    switch (status)
+    {
+    case SANDBOX_STATUS_SUCCESS:
+        return "SUCCESS";
+    case SANDBOX_STATUS_MEMORY_LIMIT_EXCEEDED:
+        return "MEMORY_LIMIT_EXCEEDED";
+    case SANDBOX_STATUS_RUNTIME_ERROR:
+        return "RUNTIME_ERROR";
+    case SANDBOX_STATUS_CPU_TIME_LIMIT_EXCEEDED:
+        return "CPU_TIME_LIMIT_EXCEEDED";
+    case SANDBOX_STATUS_REAL_TIME_LIMIT_EXCEEDED:
+        return "REAL_TIME_LIMIT_EXCEEDED";
+    case SANDBOX_STATUS_PROCESS_LIMIT_EXCEEDED:
+        return "PROCESS_LIMIT_EXCEEDED";
+    case SANDBOX_STATUS_OUTPUT_LIMIT_EXCEEDED:
+        return "OUTPUT_LIMIT_EXCEEDED";
+    case SANDBOX_STATUS_ILLEGAL_OPERATION:
+        return "ILLEGAL_OPERATION";
+    default:
+        return "INTERNAL_ERROR";
+    }
+}
+
+std::string NormalizeFormat(std::string format)
+{
+    std::transform(format.begin(), format.end(), format.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    return format;
+}
+
+void PrintResultAsJson(const SandboxResult &result)
+{
+    nlohmann::json j;
+    j["Status"]        = result.Status;
+    j["StatusName"]    = GetStatusName(result.Status);
+    j["ExitCode"]      = result.ExitCode;
+    j["Signal"]        = result.Signal;
+    j["CpuTimeUsage"]  = result.CpuTimeUsage;
+    j["RealTimeUsage"] = result.RealTimeUsage;
+    j["MemoryUsage"]   = result.MemoryUsage;
+    std::cout << j.dump() << std::endl;
+}
+
+void PrintResultAsText(const SandboxResult &result)
+{
+    std::cout << "Status:       " << GetStatusName(result.Status) << std::endl;
+    std::cout << "ExitCode:     " << result.ExitCode << std::endl;
+    std::cout << "Signal:       " << result.Signal << std::endl;
+    std::cout << "CpuTimeUsage: " << result.CpuTimeUsage << " ms" << std::endl;
+    std::cout << "RealTimeUsage:" << result.RealTimeUsage << " ms" << std::endl;
+    std::cout << "MemoryUsage:  " << result.MemoryUsage << " bytes" << std::endl;
+}
 
 char *CopyString(const std::string &s)
 {
@@ -31,7 +84,28 @@ char *CopyString(const std::string &s)
 
 } // namespace
 
-SandboxConfiguration GetSandboxConfiguration(int argc, char **argv)
+int main(int argc, char *argv[])
+{
+    auto [configuration, format] = GetCliOptions(argc, argv);
+    SandboxResult result{};
+
+    int infraStatus = StartSandbox(&configuration, &result);
+
+    if (infraStatus != SANDBOX_STATUS_SUCCESS && result.Status == 0)
+    {
+        result.Status = infraStatus;
+        fprintf(stderr, "Failed to start sandbox\n");
+    }
+
+    if (format == "json")
+        PrintResultAsJson(result);
+    else
+        PrintResultAsText(result);
+
+    return (infraStatus == SANDBOX_STATUS_SUCCESS) ? 0 : infraStatus;
+}
+
+CliOptions GetCliOptions(int argc, char **argv)
 {
     cmdline::parser parser;
     parser.add<std::string>("name", 'n', "The name of the task", false);
@@ -47,6 +121,7 @@ SandboxConfiguration GetSandboxConfiguration(int argc, char **argv)
     parser.add<int>("process", 0, "Process count limit of the task (-1 means unlimited)", false, -1);
     parser.add<uint64_t>("output-size", 0, "Output size limit of the task", false, 0);
     parser.add<std::string>("policy", 'p', "The policy name of the task", false, "default");
+    parser.add<std::string>("format", 'f', "Output format (json or text)", false, "json");
     parser.footer("program [args...]");
 
     parser.parse(argc, argv);
@@ -66,7 +141,7 @@ SandboxConfiguration GetSandboxConfiguration(int argc, char **argv)
         std::string randomName = uuids::to_string(uuids::uuid_random_generator{generator}());
         configuration.TaskName = CopyString(randomName);
     }
-    
+
     configuration.WorkingDirectory = CopyString(parser.get<std::string>("dir"));
     configuration.InputFile        = CopyString(parser.get<std::string>("input"));
     configuration.OutputFile       = CopyString(parser.get<std::string>("output"));
@@ -79,7 +154,7 @@ SandboxConfiguration GetSandboxConfiguration(int argc, char **argv)
     configuration.MaxProcessCount  = parser.get<int>("process");
     configuration.MaxOutputSize    = parser.get<uint64_t>("output-size");
     configuration.Policy           = CopyString(parser.get<std::string>("policy"));
-    
+
     if (parser.rest().empty())
     {
         fprintf(stderr, "No command specified\n");
@@ -91,5 +166,18 @@ SandboxConfiguration GetSandboxConfiguration(int argc, char **argv)
         configuration.UserCommand = CopyString(parser.rest()[0]);
     }
 
-    return configuration;
+    std::string format = NormalizeFormat(parser.get<std::string>("format"));
+    constexpr std::array<const char *, 2> kSupportedFormats = {"json", "text"};
+    const bool isSupportedFormat = std::any_of(kSupportedFormats.begin(), kSupportedFormats.end(),
+                                               [&format](const char *supportedFormat) {
+                                                   return format == supportedFormat;
+                                               });
+    if (!isSupportedFormat)
+    {
+        fprintf(stderr, "Invalid output format: %s\n", format.c_str());
+        fprintf(stderr, "Supported formats: json, text\n");
+        exit(1);
+    }
+
+    return {configuration, format};
 }

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(SandboxTest
         AbiCompatibilityTest.cpp
         PolicyRegistryTest.cpp
         ResourceConfigTest.cpp
+        SandboxRunnerCliTest.cpp
         SanitizerSandboxTest.cpp)
 
 enable_testing()
@@ -16,7 +17,9 @@ sandboxrunner_configure_target(SandboxTest)
 add_dependencies(SandboxTest SANITIZER_SAMPLES_TESTS)
 
 find_package(GTest CONFIG REQUIRED)
-target_link_libraries(SandboxTest PRIVATE GTest::gtest GTest::gmock GTest::gmock_main)
+find_package(nlohmann_json CONFIG REQUIRED)
+target_link_libraries(SandboxTest PRIVATE GTest::gtest GTest::gmock GTest::gmock_main nlohmann_json::nlohmann_json)
+add_dependencies(SandboxTest SandboxRunner)
 
 include(GoogleTest)
 gtest_discover_tests(SandboxTest

--- a/Tests/SandboxRunnerCliTest.cpp
+++ b/Tests/SandboxRunnerCliTest.cpp
@@ -1,0 +1,191 @@
+#include "SandboxTest.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <random>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#ifndef _WIN32
+#include <sys/wait.h>
+#endif
+
+namespace
+{
+
+struct CommandResult
+{
+    int ExitCode;
+    std::string StdOut;
+    std::string StdErr;
+};
+
+std::filesystem::path ResolveSandboxRunnerPath()
+{
+    const auto currentDirectory = std::filesystem::current_path();
+    const std::vector<std::filesystem::path> candidates = {
+        currentDirectory / ".." / "SandboxRunner" / "SandboxRunner",
+        currentDirectory / "SandboxRunner" / "SandboxRunner",
+#ifdef _WIN32
+        currentDirectory / ".." / "SandboxRunner" / "SandboxRunner.exe",
+        currentDirectory / "SandboxRunner" / "SandboxRunner.exe",
+#endif
+    };
+
+    for (const auto &candidate : candidates)
+    {
+        std::error_code errorCode;
+        if (std::filesystem::exists(candidate, errorCode))
+        {
+            return std::filesystem::weakly_canonical(candidate, errorCode);
+        }
+    }
+
+    return {};
+}
+
+std::string ReadTextFile(const std::filesystem::path &path)
+{
+    std::ifstream input(path);
+    std::ostringstream buffer;
+    buffer << input.rdbuf();
+    return buffer.str();
+}
+
+std::filesystem::path MakeTemporaryPath(std::string_view suffix)
+{
+    static std::mt19937_64 generator(std::random_device{}());
+    const auto randomValue = generator();
+    return std::filesystem::temp_directory_path() /
+           ("sandboxrunner-cli-" + std::to_string(randomValue) + "-" + std::string(suffix));
+}
+
+#ifdef _WIN32
+std::string QuoteShellArgument(const std::string &argument)
+{
+    std::string escaped = "\"";
+    for (const char c : argument)
+    {
+        if (c == '"')
+        {
+            escaped += "\\\"";
+            continue;
+        }
+        escaped += c;
+    }
+    escaped += "\"";
+    return escaped;
+}
+#else
+std::string QuoteShellArgument(const std::string &argument)
+{
+    std::string escaped = "'";
+    for (const char c : argument)
+    {
+        if (c == '\'')
+        {
+            escaped += "'\\''";
+            continue;
+        }
+        escaped += c;
+    }
+    escaped += "'";
+    return escaped;
+}
+#endif
+
+int DecodeExitCode(int systemResult)
+{
+#ifdef _WIN32
+    return systemResult;
+#else
+    if (WIFEXITED(systemResult))
+    {
+        return WEXITSTATUS(systemResult);
+    }
+    if (WIFSIGNALED(systemResult))
+    {
+        return 128 + WTERMSIG(systemResult);
+    }
+    return systemResult;
+#endif
+}
+
+CommandResult RunSandboxRunner(const std::vector<std::string> &arguments)
+{
+    const auto executablePath = ResolveSandboxRunnerPath();
+    EXPECT_FALSE(executablePath.empty()) << "SandboxRunner executable not found";
+
+    const auto stdoutPath = MakeTemporaryPath("stdout.txt");
+    const auto stderrPath = MakeTemporaryPath("stderr.txt");
+
+    std::string command = QuoteShellArgument(executablePath.string());
+    for (const auto &argument : arguments)
+    {
+        command += " " + QuoteShellArgument(argument);
+    }
+
+#ifdef _WIN32
+    command += " > " + QuoteShellArgument(stdoutPath.string()) + " 2> " + QuoteShellArgument(stderrPath.string());
+#else
+    command += " > " + QuoteShellArgument(stdoutPath.string()) + " 2> " + QuoteShellArgument(stderrPath.string());
+#endif
+
+    const int systemResult = std::system(command.c_str());
+
+    CommandResult result{
+        .ExitCode = DecodeExitCode(systemResult),
+        .StdOut = ReadTextFile(stdoutPath),
+        .StdErr = ReadTextFile(stderrPath),
+    };
+
+    std::error_code errorCode;
+    std::filesystem::remove(stdoutPath, errorCode);
+    errorCode.clear();
+    std::filesystem::remove(stderrPath, errorCode);
+    return result;
+}
+
+} // namespace
+
+TEST(SandboxRunnerCliTest, OutputsJsonResult)
+{
+#ifdef __linux__
+    const auto result = RunSandboxRunner({"--format", "json", "/bin/true"});
+    ASSERT_EQ(result.ExitCode, 0) << result.StdErr;
+
+    const auto json = nlohmann::json::parse(result.StdOut);
+    EXPECT_EQ(json.at("Status"), SANDBOX_STATUS_SUCCESS);
+    EXPECT_EQ(json.at("StatusName"), "SUCCESS");
+    EXPECT_EQ(json.at("ExitCode"), 0);
+    EXPECT_EQ(json.at("Signal"), 0);
+    EXPECT_TRUE(json.contains("CpuTimeUsage"));
+    EXPECT_TRUE(json.contains("RealTimeUsage"));
+    EXPECT_TRUE(json.contains("MemoryUsage"));
+#else
+    GTEST_SKIP() << "CLI sandbox execution test is only supported on Linux.";
+#endif
+}
+
+TEST(SandboxRunnerCliTest, OutputsTextResultAndRejectsInvalidFormat)
+{
+#ifdef __linux__
+    const auto textResult = RunSandboxRunner({"--format", "text", "/bin/true"});
+    ASSERT_EQ(textResult.ExitCode, 0) << textResult.StdErr;
+    EXPECT_NE(textResult.StdOut.find("Status:       SUCCESS"), std::string::npos);
+    EXPECT_NE(textResult.StdOut.find("ExitCode:     0"), std::string::npos);
+    EXPECT_NE(textResult.StdOut.find("Signal:       0"), std::string::npos);
+
+    const auto invalidFormatResult = RunSandboxRunner({"--format", "xml", "/bin/true"});
+    ASSERT_EQ(invalidFormatResult.ExitCode, 1);
+    EXPECT_NE(invalidFormatResult.StdErr.find("Invalid output format: xml"), std::string::npos);
+    EXPECT_NE(invalidFormatResult.StdErr.find("Supported formats: json, text"), std::string::npos);
+#else
+    GTEST_SKIP() << "CLI sandbox execution test is only supported on Linux.";
+#endif
+}

--- a/readme.md
+++ b/readme.md
@@ -1,24 +1,243 @@
-﻿# Sandbox Runner (C++ implementation)
+# Sandbox Runner (C++ implementation)
 
 This project is part of the HimuOJ Project.
-﻿
+
 The SandboxRunnerCore library exposes a set of C APIs to:
-﻿
-- Establish an isolated sandbox process to run user-specified commands. 
+
+- Establish an isolated sandbox process to run user-specified commands.
 - The process is immediately terminated upon attempting illegal system calls or exceeding resource limits, with the cause identified.
 - Launch the sandbox using predefined configurations or specify detailed rules in parameters: the sandbox automatically translates these rules into seccomp rules at runtime.
-﻿
+
 The library currently supports only the Linux platform.
 
-> The initial design goal of SandboxRunnerCore was an application sandbox library that could run on multiple platforms. 
-However, on Windows and MacOS, due to system call limitations, only some features were supported or not supported at all. 
-More heavyweight containers such as Docker should be used to implement on these systems.
+> The initial design goal of SandboxRunnerCore was an application sandbox library that could run on multiple platforms.
+> However, on Windows and MacOS, due to system call limitations, only some features were supported or not supported at all.
+> More heavyweight containers such as Docker should be used to implement on these systems.
 
-
-﻿
 SandboxRunner offers a straightforward command-line interface to utilize SandboxRunnerCore.
 
-
-﻿
-Typically, the SandboxRunnerCore library forms the core implementation of the code evaluation machines 
+Typically, the SandboxRunnerCore library forms the core implementation of the code evaluation machines
 in code assessment platforms.
+
+---
+
+## Building
+
+The project uses CMake with vcpkg for dependency management.
+
+```bash
+# Debug build
+cmake --preset linux-debug
+cmake --build out/build/linux-debug --parallel
+
+# Release build
+cmake --preset linux-release
+cmake --build out/build/linux-release --parallel
+```
+
+---
+
+## CLI Usage
+
+`SandboxRunner` is a command-line frontend for SandboxRunnerCore.
+
+```
+SandboxRunner [options] program [args...]
+```
+
+### Options
+
+| Flag | Short | Description | Default |
+|---|---|---|---|
+| `--name` | `-n` | Task name (used in logs) | random UUID |
+| `--dir` | `-d` | Working directory | `.` |
+| `--input` | `-i` | Redirect stdin from file | (none) |
+| `--output` | `-o` | Redirect stdout to file | (none) |
+| `--error` | `-e` | Redirect stderr to file | (none) |
+| `--log` | `-l` | Log file for sandbox diagnostics | stderr |
+| `--memory` | | Memory soft limit, bytes (`0` = unlimited) | `0` |
+| `--stack` | | Stack size limit, bytes (`0` = unlimited) | `0` |
+| `--cpu` | | CPU time limit, ms (`0` = unlimited) | `0` |
+| `--real` | | Real (wall-clock) time limit, ms (`0` = unlimited) | `0` |
+| `--process` | | Max child process count (`-1` = unlimited) | `-1` |
+| `--output-size` | | Output size limit, bytes (`0` = unlimited) | `0` |
+| `--policy` | `-p` | Policy name or JSON file path | `default` |
+| `--format` | `-f` | Result output format: `json` or `text` | `json` |
+
+### Examples
+
+Run a program with a 256 MB memory limit and 2-second time limit:
+
+```bash
+SandboxRunner --memory 268435456 --real 2000 ./solution
+```
+
+Run with I/O redirection and a custom policy:
+
+```bash
+SandboxRunner --input in.txt --output out.txt --policy cpp_policy ./solution
+```
+
+Run with strict process and output limits:
+
+```bash
+SandboxRunner --process 1 --output-size 65536 --cpu 1000 ./solution
+```
+
+Run and print a human-readable text result:
+
+```bash
+SandboxRunner --format text ./solution
+```
+
+---
+
+## C API Usage
+
+Include `Sandbox.h` and link against `SandboxRunnerCore`.
+
+### Quick Start
+
+```c
+#include "Sandbox.h"
+
+int main()
+{
+    SandboxConfiguration config = {};
+    config.TaskName     = "my-task";
+    config.UserCommand  = "/usr/bin/python3 solution.py";
+    config.InputFile    = "input.txt";
+    config.OutputFile   = "output.txt";
+    config.MaxMemory    = 256 * 1024 * 1024; // 256 MB
+    config.MaxRealTime  = 2000;              // 2 seconds
+    config.MaxCpuTime   = 1000;              // 1 second CPU
+    config.MaxProcessCount = 1;
+    config.Policy       = "default";
+
+    SandboxResult result = {};
+    int status = StartSandbox(&config, &result);
+
+    if (status == SANDBOX_STATUS_SUCCESS) {
+        printf("Exit code: %d\n", result.ExitCode);
+        printf("CPU time: %llu ms\n", result.CpuTimeUsage);
+        printf("Memory:   %llu bytes\n", result.MemoryUsage);
+    }
+    return status;
+}
+```
+
+### SandboxConfiguration Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `TaskName` | `const char *` | Task identifier used in logs. Must not be `NULL`. |
+| `UserCommand` | `const char *` | Command to execute. Must not be `NULL`. |
+| `WorkingDirectory` | `const char *` | Working directory for the child process. |
+| `EnvironmentVariables` | `const char *const *` | Null-terminated array of `KEY=VALUE` strings. |
+| `EnvironmentVariablesCount` | `uint16_t` | Number of entries in `EnvironmentVariables`. |
+| `InputFile` | `const char *` | Redirect stdin. `NULL` = inherit. |
+| `OutputFile` | `const char *` | Redirect stdout. `NULL` = inherit. |
+| `ErrorFile` | `const char *` | Redirect stderr. `NULL` = inherit. |
+| `LogFile` | `const char *` | Sandbox diagnostic log. `NULL` = write to stderr. |
+| `MaxMemory` | `uint64_t` | Soft memory limit, bytes. `0` = no limit. |
+| `MaxMemoryToCrash` | `uint64_t` | Hard memory limit, bytes. `0` = `2 × MaxMemory`. Exceeding this terminates the process with SIGSEGV/SIGABRT. |
+| `MaxStack` | `uint64_t` | Stack size limit, bytes. `0` = no limit. |
+| `MaxCpuTime` | `uint64_t` | CPU time limit, ms. `0` = no limit. |
+| `MaxRealTime` | `uint64_t` | Wall-clock time limit, ms. `0` = no limit. |
+| `MaxOutputSize` | `uint64_t` | Output size limit, bytes. `0` = no limit. |
+| `MaxProcessCount` | `int` | Max child processes. `-1` = no limit. |
+| `Policy` | `const char *` | Policy name or path (see [Policies](#policies)). `"default"` = unrestricted. |
+
+**Memory limiting behavior:** If the process exceeds `MaxMemory` but stays below `MaxMemoryToCrash`, it continues running and the result status is set to `SANDBOX_STATUS_MEMORY_LIMIT_EXCEEDED`. If it exceeds `MaxMemoryToCrash`, the kernel terminates the process immediately and the result status is `SANDBOX_STATUS_RUNTIME_ERROR`.
+
+### SandboxResult Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `Status` | `int` | Result code (see `SandboxStatus` enum) |
+| `ExitCode` | `int` | Process exit code |
+| `Signal` | `int` | Signal number if terminated by signal, otherwise `0` |
+| `CpuTimeUsage` | `uint64_t` | CPU time consumed, ms |
+| `RealTimeUsage` | `uint64_t` | Wall-clock time elapsed, ms |
+| `MemoryUsage` | `uint64_t` | Peak memory usage, bytes |
+
+### SandboxStatus Codes
+
+| Value | Meaning |
+|---|---|
+| `SANDBOX_STATUS_SUCCESS` | Process exited normally |
+| `SANDBOX_STATUS_MEMORY_LIMIT_EXCEEDED` | Memory usage exceeded `MaxMemory` |
+| `SANDBOX_STATUS_RUNTIME_ERROR` | Process crashed (non-zero exit, signal, or hard memory limit) |
+| `SANDBOX_STATUS_CPU_TIME_LIMIT_EXCEEDED` | CPU time exceeded `MaxCpuTime` |
+| `SANDBOX_STATUS_REAL_TIME_LIMIT_EXCEEDED` | Wall-clock time exceeded `MaxRealTime` |
+| `SANDBOX_STATUS_PROCESS_LIMIT_EXCEEDED` | Child process count exceeded `MaxProcessCount` |
+| `SANDBOX_STATUS_OUTPUT_LIMIT_EXCEEDED` | Output size exceeded `MaxOutputSize` |
+| `SANDBOX_STATUS_ILLEGAL_OPERATION` | Process attempted a syscall blocked by policy |
+| `SANDBOX_STATUS_INTERNAL_ERROR` | Internal sandbox error |
+
+### Validating Configuration
+
+Use `IsSandboxConfigurationVaild()` to check a configuration before running:
+
+```c
+if (!IsSandboxConfigurationVaild(&config)) {
+    fprintf(stderr, "Invalid sandbox configuration\n");
+    return 1;
+}
+int status = StartSandbox(&config, &result);
+```
+
+---
+
+## Policies
+
+Policies control which syscalls the sandboxed process is allowed to make. The built-in `"default"` policy is unrestricted. Custom policies are defined in JSON files.
+
+### JSON Policy Format
+
+Policy files use the `.json` extension. Pass the filename (with or without the extension) as the `Policy` field.
+
+```json
+{
+    "Version": "1.0",
+    "Seccomp": {
+        "AllowIO": true,
+        "RestrictExecveToProgramPath": false,
+        "WhiteList": [
+            "read",
+            "write",
+            "SCMP_SYS(exit_group)",
+            "brk",
+            60
+        ]
+    }
+}
+```
+
+### Policy Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `Version` | string | Must be `"1.0"` |
+| `Seccomp.AllowIO` | bool | Allow standard I/O syscalls (`read`, `write`, etc.). Default: `true` |
+| `Seccomp.RestrictExecveToProgramPath` | bool | Restrict `execve` to the program path only. Default: `false` |
+| `Seccomp.WhiteList` | array | Allowed syscalls as names, `SCMP_SYS(name)` macros, or integer numbers |
+
+### Example: Minimal Policy for a C Program
+
+```json
+{
+    "Version": "1.0",
+    "Seccomp": {
+        "AllowIO": true,
+        "RestrictExecveToProgramPath": true,
+        "WhiteList": [
+            "read", "write", "exit_group",
+            "brk", "mmap", "munmap",
+            "fstat", "close"
+        ]
+    }
+}
+```
+
+Save as `c_program.json` and reference it with `--policy c_program` (CLI) or `config.Policy = "c_program"` (API).


### PR DESCRIPTION
## Summary

- Add `--format`/`-f` flag to `SandboxRunner` CLI (`json` | `text`, default `json`) to control result output format
- JSON output includes `Status`, `StatusName`, `ExitCode`, `Signal`, `CpuTimeUsage`, `RealTimeUsage`, `MemoryUsage`; invalid format values are rejected with a descriptive error
- Add `SandboxRunnerCliTest.cpp` with integration tests covering JSON output, text output, and invalid-format rejection
- Expand `readme.md` with complete CLI usage table, C API reference (fields, status codes, validation), and JSON policy format docs

## Test plan

- [x] Build with `cmake --preset linux-debug && cmake --build out/build/linux-debug --parallel`
- [x] Run `ctest -R SandboxRunnerCliTest` — all tests pass
- [x] Manually verify `SandboxRunner --format json /bin/true` outputs valid JSON
- [x] Manually verify `SandboxRunner --format text /bin/true` outputs human-readable text
- [x] Manually verify `SandboxRunner --format xml /bin/true` exits with code 1 and prints an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)